### PR TITLE
Replaces default provider with "OpenAI" in image generation

### DIFF
--- a/src/AiGeekSquad.ImageGenerator.Tool/Tools/ImageGenerationTools.cs
+++ b/src/AiGeekSquad.ImageGenerator.Tool/Tools/ImageGenerationTools.cs
@@ -58,7 +58,7 @@ public class ImageGenerationTools(
             };
 
             var result = await imageService.GenerateImageAsync(
-                provider ?? DefaultProviderName,
+                provider ?? "OpenAI",
                 request);
 
             return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
@@ -101,7 +101,7 @@ public class ImageGenerationTools(
             };
 
             var result = await imageService.GenerateImageFromConversationAsync(
-                provider ?? DefaultProviderName,
+                provider ?? "OpenAI",
                 request);
 
             return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
@@ -148,7 +148,7 @@ public class ImageGenerationTools(
             };
 
             var result = await imageService.EditImageAsync(
-                provider ?? DefaultProviderName,
+                provider ?? "OpenAI",
                 request);
 
             return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
@@ -180,7 +180,7 @@ public class ImageGenerationTools(
             };
 
             var result = await imageService.CreateVariationAsync(
-                provider ?? DefaultProviderName,
+                provider ?? "OpenAI",
                 request);
 
             return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
Updates multiple image generation methods to use "OpenAI" as the default provider instead of a predefined default provider name. This change aims to align with SonarQube recommendations to improve code readability and predictability.

- Simplifies provider assignment in four image creation functions

Relates to code quality improvements and refactoring efforts.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates default provider to "OpenAI" in image generation methods and refactors `ExtractImagesFromMessages` for better readability and performance.
> 
>   - **Behavior**:
>     - Default provider changed to "OpenAI" in image generation methods.
>     - Refactored `ExtractImagesFromMessages` in `ImageProviderBase.cs` to use LINQ for improved readability and performance.
>   - **Misc**:
>     - Aligns with SonarQube recommendations for code quality improvements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AIGeekSquad%2Fimage-generator&utm_source=github&utm_medium=referral)<sup> for a22ed4c81493c08e1a845595b877d766c89e2991. You can [customize](https://app.ellipsis.dev/AIGeekSquad/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->